### PR TITLE
fix: pw crypted attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry]
+[project]
 name = "pyrad"
 version= "2.4"
 readme = "README.rst"
 license = "BSD-3-Clause"
 description="RADIUS tools"
 authors = [
-  "Istvan Ruzman <istvan@ruzman.eu>",
-  "Christian Giese <developer@gicnet.de>",
-]
+  { name = "Istvan Ruzman", email = "istvan@ruzman.eu" },
+  { name = "Christian Giese", email = "developer@gicnet.de" },
+ ]
 keywords = ["AAA", "accounting", "authentication", "authorization", "RADIUS"]
 classifiers = [
     "Development Status :: 6 - Mature",
@@ -31,11 +31,11 @@ include = [
   "example/*"
 ]
 
-[tool.poetry.urls]
+[project.urls]
 repository = "https://github.com/pyradius/pyrad"
 
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 nose = "^0.10.0b1"

--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -710,6 +710,18 @@ class AuthPacket(Packet):
 
         return header + attr
 
+    def _EncodeValue(self, attr, value):
+        if attr.encrypt == 1:
+            value = self.PwCrypt(value)
+
+        return super()._EncodeValue(attr, value)
+
+    def _DecodeValue(self, attr, value):
+        if attr.encrypt == 1:
+            value = self.PwDecrypt(value).encode()
+            
+        return super()._DecodeValue(attr, value)
+
     def PwDecrypt(self, password):
         """De-Obfuscate a RADIUS password. RADIUS hides passwords in packets by
         using an algorithm based on the MD5 hash of the packet authenticator

--- a/tests/data/full
+++ b/tests/data/full
@@ -20,6 +20,9 @@ ATTRIBUTE Test-Encrypted-String   5   string      encrypt=2
 ATTRIBUTE Test-Encrypted-Octets   6   octets      encrypt=2
 ATTRIBUTE Test-Encrypted-Integer  7   integer     encrypt=2
 
+
+ATTRIBUTE Test-PwCrypted-String     8   string      encrypt=1
+
 VENDOR Simplon 16
 
 

--- a/tests/testPacket.py
+++ b/tests/testPacket.py
@@ -539,6 +539,11 @@ class AuthPacketTests(unittest.TestCase):
         self.assertEqual(self.packet.PwDecrypt(
                 b'\xd3U;\xb23\r\x11\xba\x07\xe3\xa8*\xa8x\x14\x01'),
                 'Simplon')
+    
+    def testPwEncryptDecrypt(self):
+        self.packet.AddAttribute('Test-PwCrypted-String', 'test')
+        got = self.packet['Test-PwCrypted-String'][0]
+        self.assertEqual(got, 'test')
 
 
 class AuthPacketChapTests(unittest.TestCase):


### PR DESCRIPTION
This PR contains two fixes:

1. poetry-core version pinning + compliance to poetry-core 2.0.0
2. Encryption/Decryption of attributes with `encrypt=1`